### PR TITLE
Add dist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run build
 
 Configuration (Optional .env file)
 
-Create a .env file in the project root:
+Create a .env file in the project root (./dist):
 
 DB_USER=postgres
 DB_PASS=yourpassword


### PR DESCRIPTION
When executing the built command, we need to put the env file in the `./dist` directory to load it.
I suggest to fix it, because with project root, I think I can just place it under `sql-mcp-server` .