### PR TITLE
Fix: change order of shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,13 @@ async function shutdown(signal: string) {
       await mcpServer.close();
     }
 
-    // 2. SSHトンネルを閉じる（アクティブな場合）
+    // 2. MySQLコネクションプールを閉じる
+    if (pool) {
+      console.log('Closing MySQL connection pool...');
+      await pool.end();
+    }
+
+    // 3. SSHトンネルを閉じる（アクティブな場合）
     if (sshServer) {
       console.log('Closing SSH tunnel...');
       await new Promise<void>((resolve, reject) => {
@@ -44,12 +50,6 @@ async function shutdown(signal: string) {
           }
         });
       });
-    }
-
-    // 3. MySQLコネクションプールを閉じる
-    if (pool) {
-      console.log('Closing MySQL connection pool...');
-      await pool.end();
     }
 
     console.log('Graceful shutdown completed.');


### PR DESCRIPTION
## Problems
- Shutdown was hanging
- This is because the DB connection pool needs to be closed before closing the ssh tunnel

```bash
$ ./dist/index.js                                                                                                                                                                                                                            
^C
Received SIGINT. Starting graceful shutdown...
Closing MCP server...
Closing SSH tunnel...
```

## Changes
- Changed to close the DB connection first.

```bash
$ ./dist/index.js                                                                                                                                                                                                                            
^C
Received SIGINT. Starting graceful shutdown...
Closing MCP server...
Closing MySQL connection pool...
Closing SSH tunnel...
Graceful shutdown completed.
```