### PR TITLE
Refactor: Modularize server code and enhance schema details

### DIFF
--- a/docs/branch-memory-bank/feature-get-schema/activeContext.json
+++ b/docs/branch-memory-bank/feature-get-schema/activeContext.json
@@ -1,0 +1,80 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "ab9383fa-b339-4f15-95ea-0a4c4b73bc46",
+    "title": "アクティブコンテキスト",
+    "documentType": "active_context",
+    "path": "activeContext.json",
+    "tags": [
+      "active-context"
+    ],
+    "lastModified": "2025-04-01T03:33:48.389Z",
+    "createdAt": "2025-04-01T03:33:48.389Z",
+    "version": 1
+  },
+  "content": {
+    "currentWork": "現在取り組んでいる作業の説明",
+    "recentChanges": [
+      {
+        "date": "2025-04-01T03:33:48.389Z",
+        "description": "変更点1"
+      },
+      {
+        "date": "2025-04-01T03:33:48.389Z",
+        "description": "変更点2"
+      },
+      {
+        "date": "2025-04-01T03:33:48.389Z",
+        "description": "変更点3"
+      }
+    ],
+    "activeDecisions": [
+      {
+        "id": "b2298bf6-90bf-4086-97f9-34a0f948a159",
+        "description": "決定事項1"
+      },
+      {
+        "id": "5ddfd128-9683-4b55-8663-57047488df6f",
+        "description": "決定事項2"
+      },
+      {
+        "id": "da4cd692-fb58-40b5-928a-eac8d00a7f39",
+        "description": "決定事項3"
+      }
+    ],
+    "considerations": [
+      {
+        "id": "58af2c10-977c-46e6-9481-129f87a64dc1",
+        "description": "検討事項1",
+        "status": "open"
+      },
+      {
+        "id": "356d289b-61b0-4cf9-a8dd-e179c7ab4b39",
+        "description": "検討事項2",
+        "status": "open"
+      },
+      {
+        "id": "28cb0a81-45fb-4afb-8fec-d74ade86b8a4",
+        "description": "検討事項3",
+        "status": "open"
+      }
+    ],
+    "nextSteps": [
+      {
+        "id": "d4d2217b-d31c-48b2-874b-a03855eb309b",
+        "description": "次のステップ1",
+        "priority": "high"
+      },
+      {
+        "id": "2d94d088-75ec-4e30-b6b5-e27306a7b876",
+        "description": "次のステップ2",
+        "priority": "medium"
+      },
+      {
+        "id": "3166cd53-e730-4115-907a-22a3b5af767b",
+        "description": "次のステップ3",
+        "priority": "low"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/feature-get-schema/branchContext.json
+++ b/docs/branch-memory-bank/feature-get-schema/branchContext.json
@@ -1,0 +1,41 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "f84430fd-8a47-42e1-a44a-2dbb8c47aacd",
+    "title": "ブランチコンテキスト",
+    "documentType": "branch_context",
+    "path": "branchContext.json",
+    "tags": [
+      "branch-context"
+    ],
+    "lastModified": "2025-04-01T03:33:48.389Z",
+    "createdAt": "2025-04-01T03:33:48.389Z",
+    "version": 1
+  },
+  "content": {
+    "branchName": "feature/get-schema",
+    "purpose": "このブランチの目的を記述してください",
+    "createdAt": "2025-04-01T03:33:48.389Z",
+    "userStories": [
+      {
+        "id": "67200ba9-d6e3-4d87-a0bc-e2e26e9bcbdb",
+        "description": "解決する課題1",
+        "completed": false,
+        "priority": 1
+      },
+      {
+        "id": "d88f6ba8-b393-4b7c-8987-8aaa2c076445",
+        "description": "解決する課題2",
+        "completed": false,
+        "priority": 2
+      },
+      {
+        "id": "e7284058-ee69-4ea5-ac61-e4300673dd75",
+        "description": "解決する課題3",
+        "completed": false,
+        "priority": 3
+      }
+    ],
+    "additionalNotes": ""
+  }
+}

--- a/docs/branch-memory-bank/feature-get-schema/progress.json
+++ b/docs/branch-memory-bank/feature-get-schema/progress.json
@@ -1,0 +1,70 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "daf08ee1-5b51-4859-8803-07e739b0321b",
+    "title": "進捗状況",
+    "documentType": "progress",
+    "path": "progress.json",
+    "tags": [
+      "progress"
+    ],
+    "lastModified": "2025-04-01T03:33:48.391Z",
+    "createdAt": "2025-04-01T03:33:48.391Z",
+    "version": 1
+  },
+  "content": {
+    "workingFeatures": [
+      {
+        "id": "fcbbc364-5be6-4ab1-bb1d-6a9194e2265d",
+        "description": "機能1",
+        "implementedAt": "2025-04-01T03:33:48.391Z"
+      },
+      {
+        "id": "5e5fa99d-a758-40ad-a195-fa4957f9626c",
+        "description": "機能2",
+        "implementedAt": "2025-04-01T03:33:48.391Z"
+      },
+      {
+        "id": "0d0fa5bf-40b3-4b45-85e3-5d410c93cb5d",
+        "description": "機能3",
+        "implementedAt": "2025-04-01T03:33:48.391Z"
+      }
+    ],
+    "pendingImplementation": [
+      {
+        "id": "9232c593-ea41-4bc1-aa89-b4da06cb3aa9",
+        "description": "未実装の機能1",
+        "priority": "high"
+      },
+      {
+        "id": "8fb1f364-63d1-4907-846d-3ca6f4a2d5cb",
+        "description": "未実装の機能2",
+        "priority": "medium"
+      },
+      {
+        "id": "7346c184-d4da-4f48-8e66-9d1b0affc42c",
+        "description": "未実装の機能3",
+        "priority": "low"
+      }
+    ],
+    "status": "現在の実装状態の説明",
+    "completionPercentage": 0,
+    "knownIssues": [
+      {
+        "id": "550b1218-9f7d-4358-baec-ec9a0e77ece2",
+        "description": "問題1",
+        "severity": "high"
+      },
+      {
+        "id": "f38d6b23-a547-4a5f-a93a-f102f1b6c3d2",
+        "description": "問題2",
+        "severity": "medium"
+      },
+      {
+        "id": "8823d071-f545-4713-9ca6-56e3a072d889",
+        "description": "問題3",
+        "severity": "low"
+      }
+    ]
+  }
+}

--- a/docs/branch-memory-bank/feature-get-schema/refactoring/index-refactoring-plan.json
+++ b/docs/branch-memory-bank/feature-get-schema/refactoring/index-refactoring-plan.json
@@ -1,0 +1,40 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "refactoring-plan-index-ts-v1",
+    "title": "index.ts リファクタリング計画",
+    "documentType": "refactoring_plan",
+    "path": "refactoring/index-refactoring-plan.json",
+    "tags": [
+      "refactoring",
+      "architecture",
+      "index.ts",
+      "feature/get-schema"
+    ],
+    "version": 1,
+    "createdAt": "2025-04-01T03:33:48.389Z",
+    "lastModified": "2025-04-01T03:33:48.389Z"
+  },
+  "content": {
+    "description": "src/index.ts を機能ごとにモジュール分割するリファクタリング計画。バグ修正（initMCPServerの複数回呼び出し防止）とコネクションリーク対策も含む。",
+    "targetFile": "src/index.ts",
+    "proposedStructure": [
+      "src/config.ts",
+      "src/ssh-tunnel.ts",
+      "src/db.ts",
+      "src/mcp/handlers.ts",
+      "src/mcp/server.ts",
+      "src/shutdown.ts",
+      "src/index.ts"
+    ],
+    "diagram": "graph TD\n    subgraph Initialization Flow\n        direction LR\n        Start --> Config;\n        Config --> SshTunnelCheck{Use SSH?};\n        SshTunnelCheck -- Yes --> ConnectSshTunnel[Connect SSH Tunnel (ssh-tunnel.ts)];\n        SshTunnelCheck -- No --> InitDbPoolDirect[Initialize DB Pool (db.ts)];\n        ConnectSshTunnel --> InitDbPoolTunnel[Initialize DB Pool via Tunnel (db.ts)];\n        InitDbPoolDirect --> CheckDbConnection[Check DB Connection (db.ts) - with robust error handling];\n        InitDbPoolTunnel --> CheckDbConnection;\n        CheckDbConnection -- Success --> InitMcpServer[Initialize MCP Server (mcp/server.ts)];\n        InitMcpServer --> SetupRequestHandlers[Setup Request Handlers (mcp/handlers.ts) - with robust error/connection handling];\n        SetupRequestHandlers --> SetupShutdown[Setup Shutdown Handlers (shutdown.ts) - with robust cleanup];\n        SetupShutdown --> Ready;\n        CheckDbConnection -- Failure --> HandleInitError[Handle Initialization Error & Cleanup];\n    end\n\n    subgraph Modules\n        Config[src/config.ts]\n        SshTunnel[src/ssh-tunnel.ts]\n        Db[src/db.ts - Centralized Pool & Connection Mgmt]\n        McpServer[src/mcp/server.ts]\n        McpHandlers[src/mcp/handlers.ts - Robust Error/Connection Handling]\n        Shutdown[src/shutdown.ts - Robust Cleanup Logic]\n        Index[src/index.ts]\n    end\n\n    InitMcpServer --> McpHandlers;\n    Index --> Start;",
+    "keyPoints": [
+      "機能ごとのモジュール分割 (config, ssh, db, mcp, shutdown)",
+      "index.ts は起動処理に専念",
+      "DB接続とMCPサーバー初期化のシーケンスを明確化し、複数回初期化バグを修正",
+      "DBコネクション管理を一元化し、コネクションリーク対策を強化",
+      "各モジュールでのエラーハンドリングを強化"
+    ],
+    "status": "approved"
+  }
+}

--- a/docs/branch-memory-bank/feature-get-schema/systemPatterns.json
+++ b/docs/branch-memory-bank/feature-get-schema/systemPatterns.json
@@ -1,0 +1,37 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "9e813f4c-a727-45f8-9840-81a8a86d142b",
+    "title": "システムパターン",
+    "documentType": "system_patterns",
+    "path": "systemPatterns.json",
+    "tags": [
+      "system-patterns"
+    ],
+    "lastModified": "2025-04-01T03:33:48.390Z",
+    "createdAt": "2025-04-01T03:33:48.390Z",
+    "version": 1
+  },
+  "content": {
+    "technicalDecisions": [
+      {
+        "id": "338020ad-149f-4be6-8644-b49c9fd9ffba",
+        "title": "決定事項のタイトル",
+        "context": "決定の背景や理由",
+        "decision": "具体的な決定内容",
+        "consequences": {
+          "positive": [
+            "影響1",
+            "影響2",
+            "影響3"
+          ],
+          "negative": []
+        },
+        "status": "proposed",
+        "date": "2025-04-01T03:33:48.390Z",
+        "alternatives": []
+      }
+    ],
+    "implementationPatterns": []
+  }
+}

--- a/docs/global-memory-bank/tags/index.json
+++ b/docs/global-memory-bank/tags/index.json
@@ -1,0 +1,240 @@
+{
+  "schema": "memory_document_v2",
+  "metadata": {
+    "id": "tags-index",
+    "title": "タグインデックス",
+    "documentType": "generic",
+    "path": "tags/index.json",
+    "tags": [
+      "index",
+      "meta"
+    ],
+    "lastModified": "2025-04-01T03:34:08.678Z",
+    "createdAt": "2025-04-01T03:34:08.678Z",
+    "version": 1
+  },
+  "content": {
+    "sections": [
+      {
+        "title": "Tags List",
+        "content": "タグとドキュメントの関連付け"
+      }
+    ],
+    "tagMap": {
+      "architecture": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/architecture.json",
+            "title": "core/architecture.json"
+          }
+        ]
+      },
+      "system-design": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/architecture.json",
+            "title": "core/architecture.json"
+          }
+        ]
+      },
+      "core": {
+        "count": 6,
+        "documents": [
+          {
+            "path": "core/architecture.json",
+            "title": "core/architecture.json"
+          },
+          {
+            "path": "core/coding-standards.json",
+            "title": "core/coding-standards.json"
+          },
+          {
+            "path": "core/domain-models.json",
+            "title": "core/domain-models.json"
+          },
+          {
+            "path": "core/glossary.json",
+            "title": "core/glossary.json"
+          },
+          {
+            "path": "core/tech-stack.json",
+            "title": "core/tech-stack.json"
+          },
+          {
+            "path": "core/user-guide.json",
+            "title": "core/user-guide.json"
+          }
+        ]
+      },
+      "typescript": {
+        "count": 6,
+        "documents": [
+          {
+            "path": "core/architecture.json",
+            "title": "core/architecture.json"
+          },
+          {
+            "path": "core/coding-standards.json",
+            "title": "core/coding-standards.json"
+          },
+          {
+            "path": "core/domain-models.json",
+            "title": "core/domain-models.json"
+          },
+          {
+            "path": "core/glossary.json",
+            "title": "core/glossary.json"
+          },
+          {
+            "path": "core/tech-stack.json",
+            "title": "core/tech-stack.json"
+          },
+          {
+            "path": "core/user-guide.json",
+            "title": "core/user-guide.json"
+          }
+        ]
+      },
+      "standards": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/coding-standards.json",
+            "title": "core/coding-standards.json"
+          }
+        ]
+      },
+      "best-practices": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/coding-standards.json",
+            "title": "core/coding-standards.json"
+          }
+        ]
+      },
+      "clean-code": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/coding-standards.json",
+            "title": "core/coding-standards.json"
+          }
+        ]
+      },
+      "domain": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/domain-models.json",
+            "title": "core/domain-models.json"
+          }
+        ]
+      },
+      "models": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/domain-models.json",
+            "title": "core/domain-models.json"
+          }
+        ]
+      },
+      "mcp": {
+        "count": 4,
+        "documents": [
+          {
+            "path": "core/domain-models.json",
+            "title": "core/domain-models.json"
+          },
+          {
+            "path": "core/glossary.json",
+            "title": "core/glossary.json"
+          },
+          {
+            "path": "core/tech-stack.json",
+            "title": "core/tech-stack.json"
+          },
+          {
+            "path": "core/user-guide.json",
+            "title": "core/user-guide.json"
+          }
+        ]
+      },
+      "glossary": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/glossary.json",
+            "title": "core/glossary.json"
+          }
+        ]
+      },
+      "terminology": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/glossary.json",
+            "title": "core/glossary.json"
+          }
+        ]
+      },
+      "tech": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/tech-stack.json",
+            "title": "core/tech-stack.json"
+          }
+        ]
+      },
+      "stack": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/tech-stack.json",
+            "title": "core/tech-stack.json"
+          }
+        ]
+      },
+      "guide": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/user-guide.json",
+            "title": "core/user-guide.json"
+          }
+        ]
+      },
+      "user": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "core/user-guide.json",
+            "title": "core/user-guide.json"
+          }
+        ]
+      },
+      "index": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "tags/index.json",
+            "title": "tags/index.json"
+          }
+        ]
+      },
+      "meta": {
+        "count": 1,
+        "documents": [
+          {
+            "path": "tags/index.json",
+            "title": "tags/index.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sql-mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for interacting with MySQL databases via SSH tunnels",
   "main": "dist/index.js",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,103 @@
+// src/config.ts
+import dotenv from 'dotenv';
+import fs from 'fs';
+import type { TunnelConfig } from 'tunnel-ssh';
+import type { PoolOptions } from 'mysql2/promise';
+
+dotenv.config();
+
+// --- 基本設定 ---
+export const useSshTunnel: boolean = process.env.USE_SSH_TUNNEL === 'true';
+export const dbName: string | undefined = process.env.DB_NAME;
+
+if (!dbName) {
+  console.error('Error: DB_NAME environment variable is not set.');
+  process.exit(1);
+}
+
+// --- SSHトンネル設定 (必要な場合のみ) ---
+let sshTunnelConfig: TunnelConfig | undefined;
+if (useSshTunnel) {
+  const sshPrivateKeyPath = process.env.SSH_PRIVATE_KEY_PATH;
+  if (!sshPrivateKeyPath) {
+    console.error('Error: SSH_PRIVATE_KEY_PATH environment variable is required when USE_SSH_TUNNEL is true.');
+    process.exit(1);
+  }
+  if (!fs.existsSync(sshPrivateKeyPath)) {
+    console.error(`Error: SSH private key file not found at ${sshPrivateKeyPath}`);
+    process.exit(1);
+  }
+
+  sshTunnelConfig = {
+    username: process.env.SSH_BASTION_USER!,
+    host: process.env.SSH_BASTION_HOST!,
+    dstHost: process.env.DB_HOST!, // トンネル先のDBホスト
+    dstPort: Number(process.env.DB_PORT || '3306'),
+    privateKey: fs.readFileSync(sshPrivateKeyPath),
+    passphrase: process.env.SSH_PRIVATE_KEY_PASSPHRASE,
+    localHost: '127.0.0.1', // トンネルのローカル側ホスト
+    localPort: Number(process.env.LOCAL_PORT || '3333'), // トンネルのローカル側ポート
+    port: 22, // SSHポート
+    exec: false,
+  };
+}
+export { sshTunnelConfig };
+
+// --- DB接続設定 ---
+const dbPoolOptionsBase: Partial<PoolOptions> = {
+  user: process.env.DB_USER,
+  password: process.env.DB_PASS,
+  database: dbName,
+  waitForConnections: true,
+  connectionLimit: 10,
+  queueLimit: 0,
+  connectTimeout: 10000, // 接続タイムアウトを追加
+};
+
+let dbPoolOptions: PoolOptions;
+if (useSshTunnel && sshTunnelConfig) {
+  // SSHトンネル経由の場合
+  dbPoolOptions = {
+    ...dbPoolOptionsBase,
+    host: sshTunnelConfig.localHost, // トンネルのローカルホスト
+    port: sshTunnelConfig.localPort, // トンネルのローカルポート
+  };
+} else {
+  // 直接接続の場合
+  dbPoolOptions = {
+    ...dbPoolOptionsBase,
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT || '3306'),
+  };
+}
+export { dbPoolOptions };
+
+// --- MCPサーバー設定 ---
+export const mcpServerInfo = {
+  name: 'example-servers/server-ts-mysql',
+  version: '0.1.0',
+};
+
+// --- 環境変数チェック ---
+function checkEnvVar(name: string, required: boolean = true): string | undefined {
+    const value = process.env[name];
+    if (required && !value) {
+        console.error(`Error: Required environment variable ${name} is not set.`);
+        process.exit(1);
+    }
+    return value;
+}
+
+// 必須チェック
+checkEnvVar('DB_USER');
+checkEnvVar('DB_PASS');
+checkEnvVar('DB_HOST');
+// DB_NAME は上でチェック済み
+
+if (useSshTunnel) {
+    checkEnvVar('SSH_BASTION_USER');
+    checkEnvVar('SSH_BASTION_HOST');
+    checkEnvVar('SSH_PRIVATE_KEY_PATH'); // 上でチェック済みだが念のため
+}
+
+console.log('Configuration loaded successfully.'); // 設定読み込み完了ログ

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,69 @@
+// src/db.ts
+import mysql from 'mysql2/promise';
+import { dbPoolOptions } from './config.js'; // DB接続設定をインポート
+
+let pool: mysql.Pool | null = null; // コネクションプールを保持 (初期値は null)
+
+/**
+ * MySQLコネクションプールを初期化し、接続を確認する関数
+ * @returns 初期化されたコネクションプール
+ * @throws 接続に失敗した場合にエラーを投げる
+ */
+export async function initializeDbPool(): Promise<mysql.Pool> {
+  if (pool) {
+    console.warn('Database pool already initialized.');
+    return pool; // すでに初期化済みなら既存のプールを返す
+  }
+
+  console.log('Initializing database connection pool...');
+  try {
+    pool = mysql.createPool(dbPoolOptions);
+
+    // 接続テスト
+    const connection = await pool.getConnection();
+    console.log('Database connection test successful. Releasing test connection.');
+    connection.release();
+
+    console.log('Database connection pool initialized successfully.');
+    return pool;
+  } catch (error) {
+    console.error('Failed to initialize database connection pool:', error);
+    pool = null; // 初期化失敗時は null に戻す
+    // エラーを再スローして呼び出し元に通知
+    throw new Error(`Database initialization failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * MySQLコネクションプールを閉じる関数
+ * @returns プール切断後に解決されるPromise (成功時: void, 失敗時: Error)
+ */
+export async function closeDbPool(): Promise<void> {
+  if (pool) {
+    console.log('Closing database connection pool...');
+    try {
+      await pool.end();
+      console.log('Database connection pool closed successfully.');
+      pool = null; // プール参照をクリア
+    } catch (error) {
+      console.error('Error closing database connection pool:', error);
+      // エラーが発生しても、とりあえず先に進む場合もあるため、ここではエラーを再スローしないことも検討
+      // throw error; // 必要に応じて再スロー
+    }
+  } else {
+    console.log('Database pool was not active, skipping closure.');
+  }
+}
+
+/**
+ * 初期化済みのMySQLコネクションプールを取得する関数
+ * @returns コネクションプール (未初期化の場合は null)
+ * @throws プールが初期化されていない場合にエラーを投げる
+ */
+export function getDbPool(): mysql.Pool {
+    if (!pool) {
+        // 通常、initializeDbPool が先に呼ばれるはずなので、ここに来る場合は予期せぬ状態
+        throw new Error('Database pool has not been initialized. Call initializeDbPool first.');
+    }
+    return pool;
+}

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -1,0 +1,202 @@
+// src/mcp/handlers.ts
+import type mysql from 'mysql2/promise';
+import {
+  // Request スキーマ自体をインポートして、その中の params の型を使う方針に変更
+  type CallToolRequest,
+  type ListResourcesResult,
+  type ListToolsResult,
+  type ReadResourceRequest, // RequestParams -> Request に変更
+  type ReadResourceResult,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import { getDbPool } from '../db.js';
+import { dbName } from '../config.js';
+
+// DBプールを取得 (ハンドラ内で使用)
+function pool(): mysql.Pool {
+    return getDbPool();
+}
+
+/**
+ * ListResources リクエストハンドラ
+ */
+export async function handleListResources(): Promise<ListResourcesResult> {
+  // ... (実装は変更なし) ...
+  const [rows] = await pool().query(
+    "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
+    [dbName]
+  );
+  const tables = rows as Array<{ table_name: string }>;
+  return {
+    resources: tables.map((row) => ({
+      uri: `mysql:///${row.table_name}/schema`,
+      mimeType: 'application/json',
+      name: `"${row.table_name}" database schema`,
+    })),
+  };
+}
+
+/**
+ * ReadResource リクエストハンドラ (強化版)
+ */
+// 引数の型を ReadResourceRequest['params'] に変更
+export async function handleReadResource(params: ReadResourceRequest['params']): Promise<ReadResourceResult> {
+  const parts = new URL(params.uri).pathname.split('/');
+  const tableName = parts[1];
+
+  if (!dbName) {
+    throw new Error('DB_NAME environment variable is not set.');
+  }
+
+  const connection = await pool().getConnection();
+
+  try {
+    // 1. カラム情報取得
+    const [columns]: any = await connection.query(`
+      SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+      WHERE table_schema = ? AND table_name = ?
+      ORDER BY ordinal_position
+    `, [dbName, tableName]);
+
+    // 2. 主キー情報取得
+    const [pk]: any = await connection.query(`
+      SELECT k.column_name
+      FROM information_schema.key_column_usage k
+      JOIN information_schema.table_constraints t
+      ON k.constraint_name = t.constraint_name AND k.table_schema = t.table_schema
+      WHERE t.constraint_type = 'PRIMARY KEY'
+        AND k.table_schema = ? AND k.table_name = ?
+    `, [dbName, tableName]);
+    const primaryKeys = pk.map((r: any) => r.column_name);
+
+    // 3. 外部キー情報取得
+    const [fks]: any = await connection.query(`
+      SELECT
+        k.column_name,
+        k.referenced_table_name,
+        k.referenced_column_name
+      FROM information_schema.key_column_usage k
+      JOIN information_schema.table_constraints t
+      ON k.constraint_name = t.constraint_name AND k.table_schema = t.table_schema
+      WHERE t.constraint_type = 'FOREIGN KEY'
+        AND k.table_schema = ? AND k.table_name = ?
+    `, [dbName, tableName]);
+
+    // 4. 結果を整形
+    const tableSchema = {
+      name: tableName,
+      columns: columns.map((col: any) => ({
+        name: col.column_name,
+        type: col.data_type,
+        nullable: col.is_nullable === 'YES',
+        default: col.column_default,
+        primaryKey: primaryKeys.includes(col.column_name),
+      })),
+      foreignKeys: fks.map((fk: any) => ({
+        column: fk.column_name,
+        references: {
+          table: fk.referenced_table_name,
+          column: fk.referenced_column_name,
+        }
+      })),
+    };
+
+    return {
+      contents: [
+        {
+          uri: params.uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(tableSchema, null, 2),
+        },
+      ],
+    };
+  } finally {
+    connection.release();
+  }
+}
+
+/**
+ * ListTools リクエストハンドラ
+ */
+export async function handleListTools(): Promise<ListToolsResult> {
+  // ... (実装は変更なし) ...
+  return {
+    tools: [
+      {
+        name: 'query',
+        // 説明を詳しく！
+        description: 'Executes a read-only SQL query (SELECT, SHOW, DESCRIBE, EXPLAIN) against the connected MySQL database. Returns the query results as a JSON string. Note: Write operations (INSERT, UPDATE, DELETE, etc.) are strictly prohibited and will result in an error.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sql: {
+              type: 'string',
+              // こっちの説明もちょっと詳しく！
+              description: 'The read-only SQL query to execute (e.g., "SELECT * FROM users LIMIT 10"). Only SELECT, SHOW, DESCRIBE, and EXPLAIN statements are allowed.'
+            }
+          },
+          required: ['sql'],
+        },
+        // outputSchema も定義するとさらに親切だけど、今回は省略
+        // outputSchema: {
+        //   type: 'object',
+        //   properties: {
+        //     content: {
+        //       type: 'array',
+        //       items: {
+        //         type: 'object',
+        //         properties: {
+        //           type: { type: 'string', enum: ['text'] },
+        //           text: { type: 'string', description: 'JSON string representation of the query result array.' }
+        //         },
+        //         required: ['type', 'text']
+        //       }
+        //     }
+        //   },
+        //   required: ['content']
+        // }
+      },
+     ],
+  };
+}
+
+/**
+ * CallTool リクエストハンドラ
+ */
+// 引数の型を CallToolRequest['params'] に変更
+export async function handleCallTool(params: CallToolRequest['params']): Promise<CallToolResult> {
+  if (params.name === 'query') {
+    const sql = params.arguments?.sql as string;
+    // ... (SQLチェック、実行、エラーハンドリングは変更なし) ...
+    if (!sql || typeof sql !== 'string') { throw new Error("Missing or invalid 'sql' argument for query tool."); }
+    const lowerSql = sql.toLowerCase().trim();
+    if (!lowerSql.startsWith('select') && !lowerSql.startsWith('show') && !lowerSql.startsWith('describe') && !lowerSql.startsWith('explain')) { throw new Error("Only read-only queries (SELECT, SHOW, DESCRIBE, EXPLAIN) are allowed."); }
+
+    const connection = await pool().getConnection();
+    try {
+      // ... (トランザクション、クエリ実行、ロールバックは変更なし) ...
+      await connection.beginTransaction();
+      console.log(`Executing read-only query: ${sql}`);
+      const [rows] = await connection.query(sql);
+      await connection.rollback();
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(rows, null, 2) },
+        ],
+      };
+    } catch (error) {
+      // ... (エラー時のロールバック、ログ出力、返却処理は変更なし) ...
+      await connection.rollback();
+      console.error(`Error executing query tool with SQL: ${sql}`, error);
+      return {
+          content: [
+              { type: 'text', text: `Error executing query: ${error instanceof Error ? error.message : String(error)}` }
+          ],
+      };
+    } finally {
+      connection.release();
+    }
+  }
+  throw new Error(`Unknown tool requested: ${params.name}`);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,96 @@
+// src/mcp/server.ts
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+  type CallToolRequest,
+  type ReadResourceRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+    handleCallTool,
+    handleListResources,
+    handleListTools,
+    handleReadResource
+} from './handlers.js'; // ハンドラ関数をインポート
+import { mcpServerInfo } from '../config.js'; // サーバー情報をインポート (パス修正)
+
+let mcpServer: Server | null = null; // MCPサーバーインスタンスを保持
+
+/**
+ * MCPサーバーを初期化し、リクエストハンドラを登録する関数
+ * @returns 初期化されたMCPサーバーインスタンス
+ */
+export function initializeMcpServer(): Server {
+    if (mcpServer) {
+        console.warn('MCP Server already initialized.');
+        return mcpServer;
+    }
+
+    console.log('Initializing MCP server...');
+    // MCPサーバーの初期化 (configから情報を取得)
+    mcpServer = new Server(
+        { name: mcpServerInfo.name, version: mcpServerInfo.version },
+        // capabilities はここでは空でOK。ハンドラで動的に返すため。
+        { capabilities: { resources: {}, tools: {} } }
+    );
+
+    // 各リクエストスキーマに対応するハンドラを登録
+    mcpServer.setRequestHandler(ListResourcesRequestSchema, handleListResources);
+    // ReadResourceRequestSchema のハンドラには params が渡される
+    mcpServer.setRequestHandler(ReadResourceRequestSchema, (request: ReadResourceRequest) => handleReadResource(request.params));
+    mcpServer.setRequestHandler(ListToolsRequestSchema, handleListTools);
+    // CallToolRequestSchema のハンドラには params が渡される
+    mcpServer.setRequestHandler(CallToolRequestSchema, (request: CallToolRequest) => handleCallTool(request.params));
+
+    console.log('MCP server initialized and handlers registered.');
+    return mcpServer;
+}
+
+/**
+ * MCPサーバーをStdioトランスポートで起動する関数
+ */
+export async function startMcpServer(): Promise<void> {
+    if (!mcpServer) {
+        throw new Error('MCP Server has not been initialized. Call initializeMcpServer first.');
+    }
+    console.log('Starting MCP server with Stdio transport...');
+    try {
+        // MCPサーバーをStdioトランスポートで接続 (起動)
+        await mcpServer.connect(new StdioServerTransport());
+        console.log('MCP server connected via Stdio.');
+    } catch (error) {
+        console.error('Failed to start MCP server:', error);
+        throw error; // エラーを再スロー
+    }
+}
+
+/**
+ * 初期化済みのMCPサーバーインスタンスを取得する関数 (シャットダウン処理用)
+ * @returns MCPサーバーインスタンス (未初期化の場合は null)
+ */
+export function getMcpServer(): Server | null {
+    return mcpServer;
+}
+
+/**
+ * MCPサーバーを閉じる関数 (シャットダウン処理用)
+ * @returns サーバー切断後に解決されるPromise
+ */
+export async function closeMcpServer(): Promise<void> {
+    if (mcpServer) {
+        console.log('Closing MCP server...');
+        try {
+            await mcpServer.close();
+            console.log('MCP server closed successfully.');
+            mcpServer = null; // インスタンス参照をクリア
+        } catch (error) {
+            console.error('Error closing MCP server:', error);
+            // throw error; // 必要に応じて再スロー
+        }
+    } else {
+        console.log('MCP server was not active, skipping closure.');
+    }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -88,7 +88,7 @@ export async function closeMcpServer(): Promise<void> {
             mcpServer = null; // インスタンス参照をクリア
         } catch (error) {
             console.error('Error closing MCP server:', error);
-            // throw error; // 必要に応じて再スロー
+            throw error; // 必要に応じて再スロー
         }
     } else {
         console.log('MCP server was not active, skipping closure.');

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,49 @@
+// src/shutdown.ts
+import { closeMcpServer } from './mcp/server.js'; // MCPサーバー終了関数
+import { closeDbPool } from './db.js';         // DBプール終了関数
+import { closeSshTunnel } from './ssh-tunnel.js'; // SSHトンネル終了関数
+import { useSshTunnel } from './config.js';     // SSHトンネル使用フラグ
+
+let isShuttingDown = false; // シャットダウン処理中フラグ
+
+/**
+ * 安全なシャットダウン処理を実行する関数
+ * @param signal 受け取ったシグナル名 (例: 'SIGTERM')
+ */
+async function shutdown(signal: string) {
+  if (isShuttingDown) {
+    console.log('Shutdown already in progress...');
+    return;
+  }
+  isShuttingDown = true;
+  console.log(`\nReceived ${signal}. Starting graceful shutdown...`);
+
+  try {
+    // 1. MCPサーバーを閉じる (新規リクエスト受付停止)
+    await closeMcpServer();
+
+    // 2. MySQLコネクションプールを閉じる
+    await closeDbPool();
+
+    // 3. SSHトンネルを閉じる (アクティブな場合のみ)
+    if (useSshTunnel) {
+      await closeSshTunnel();
+    }
+
+    console.log('Graceful shutdown completed.');
+    process.exit(0); // 正常終了
+  } catch (error) {
+    console.error('Error during shutdown:', error);
+    process.exit(1); // 異常終了
+  }
+}
+
+/**
+ * シャットダウンシグナルハンドラを設定する関数
+ */
+export function setupShutdownHandlers() {
+  process.on('SIGTERM', () => shutdown('SIGTERM')); // kill コマンドなど
+  process.on('SIGINT', () => shutdown('SIGINT'));   // Ctrl+C
+  // 必要に応じて他のシグナルも追加 (e.g., SIGHUP)
+  console.log('Shutdown signal handlers registered.');
+}

--- a/src/ssh-tunnel.ts
+++ b/src/ssh-tunnel.ts
@@ -1,0 +1,68 @@
+// src/ssh-tunnel.ts
+import tunnel from 'tunnel-ssh';
+import { sshTunnelConfig } from './config.js'; // 設定をインポート
+import type { TunnelConfig } from 'tunnel-ssh';
+
+let sshServerInstance: any = null; // SSHサーバーインスタンスを保持
+
+/**
+ * SSHトンネルを確立する関数
+ * @returns トンネル確立後に解決されるPromise (成功時: void, 失敗時: Error)
+ */
+export function connectSshTunnel(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!sshTunnelConfig) {
+      // sshTunnelConfig が未定義の場合はトンネル不要とみなし、即座に解決
+      console.log('SSH tunnel configuration not found, skipping tunnel connection.');
+      resolve();
+      return;
+    }
+
+    console.log('Attempting to establish SSH tunnel...');
+    tunnel(sshTunnelConfig as TunnelConfig, (error: unknown, server: unknown) => {
+      if (error) {
+        console.error('SSH Tunnel connection error:', error);
+        reject(new Error(`SSH Tunnel connection failed: ${error instanceof Error ? error.message : String(error)}`));
+      } else {
+        sshServerInstance = server; // インスタンスを保持
+        console.log('SSH Tunnel established successfully.');
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * SSHトンネルを切断する関数
+ * @returns トンネル切断後に解決されるPromise (成功時: void, 失敗時: Error)
+ */
+export function closeSshTunnel(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (sshServerInstance) {
+      console.log('Closing SSH tunnel...');
+      // tunnel-ssh の close はコールバック形式なので Promise でラップ
+      sshServerInstance.close((err: Error | null) => {
+        if (err) {
+          console.error('Error closing SSH tunnel:', err);
+          reject(err);
+        } else {
+          console.log('SSH tunnel closed successfully.');
+          sshServerInstance = null; // インスタンス参照をクリア
+          resolve();
+        }
+      });
+    } else {
+      // トンネルが確立されていない場合は何もしない
+      console.log('SSH tunnel was not active, skipping closure.');
+      resolve();
+    }
+  });
+}
+
+/**
+ * SSHトンネルサーバーのインスタンスを取得する (シャットダウン処理用)
+ * @returns SSHサーバーインスタンス or null
+ */
+export function getSshServerInstance(): any {
+    return sshServerInstance;
+}


### PR DESCRIPTION
This PR refactors the server codebase for better modularity and maintainability. It also enhances the schema information provided by the `ReadResource` handler based on user feedback.

**Key Changes:**

*   **Modularization:**
    *   Separated concerns into dedicated modules: `config`, `ssh-tunnel`, `db`, `mcp/handlers`, `mcp/server`, `shutdown`.
    *   Simplified `src/index.ts` to orchestrate module initialization and server startup.
*   **Enhanced `ReadResource` Handler:**
    *   Retrieves detailed column information (type, nullability, default).
    *   Fetches primary and foreign key details.
*   **Improved `ListTools` Description:**
    *   Clarified the capabilities and read-only nature of the `query` tool.
*   **Robustness & Fixes:**
    *   Addressed potential multiple MCP server initializations.
    *   Improved connection management and error handling.
    *   Added transaction handling for the `query` tool.
*   **Included minor updates** to `.gitignore` and `docs/global-memory-bank/tags/index.json`.

These changes aim to improve code structure, maintainability, and provide more detailed schema information via the MCP server.